### PR TITLE
Add Long field type

### DIFF
--- a/examples/coinbase-example/data/market-data/FIX50-prod-sand.xml
+++ b/examples/coinbase-example/data/market-data/FIX50-prod-sand.xml
@@ -167,7 +167,7 @@
         <field number='55' name='Symbol' type='STRING' />
         <field number='58' name='Text' type='STRING' />
         <field number='60' name='TransactTime' type='UTCTIMESTAMP' />
-        <field number='83' name='RptSeq' type='INT' />
+        <field number='83' name='RptSeq' type='LONG' />
         <field number='107' name='SecurityDesc' type='STRING' />
         <field number='110' name='MinQty' type='QTY' />
         <field number='120' name='SettlCurrency' type='CURRENCY' />

--- a/quickfix-msg-gen/src/lib.rs
+++ b/quickfix-msg-gen/src/lib.rs
@@ -118,7 +118,7 @@ fn generate_field_types(output: &mut String, field_specs: &[FieldSpec]) {
     for field_spec in field_specs {
         if !field_spec.values.is_empty() {
             match &field_spec.r#type {
-                FieldType::Int => {
+                FieldType::Int | FieldType::Long => {
                     generate_field_type_int_values(output, field_spec);
                 }
                 _ => {
@@ -135,7 +135,10 @@ fn generate_field_types(output: &mut String, field_specs: &[FieldSpec]) {
 
 fn generate_field_type_int_values(output: &mut String, field_spec: &FieldSpec) {
     assert!(!field_spec.values.is_empty());
-    assert!(matches!(field_spec.r#type, FieldType::Int));
+    assert!(matches!(
+        field_spec.r#type,
+        FieldType::Int | FieldType::Long
+    ));
 
     let enum_name = field_spec.name.as_str();
 
@@ -243,6 +246,7 @@ fn generate_field_type_alias(output: &mut String, field_spec: &FieldSpec) {
     let type_name = field_spec.name.as_str();
     let rust_type = match &field_spec.r#type {
         FieldType::Int => "i64",
+        FieldType::Long => "i128",
         FieldType::Length => "u32",
         FieldType::SequenceNumber => "u32",
         FieldType::NumberInGroup => "i32",

--- a/quickfix-spec-parser/src/model/field_type.rs
+++ b/quickfix-spec-parser/src/model/field_type.rs
@@ -52,6 +52,8 @@ pub enum FieldType {
     XidRef,
     Xid,
     LocalMarketTime,
+    // ⬆️ Not part of any FIX spec but known types.
+    Long,
 }
 
 impl FieldType {
@@ -60,6 +62,7 @@ impl FieldType {
         match self {
             Self::Char => "CHAR",
             Self::Int => "INT",
+            Self::Long => "LONG",
             Self::Float => "FLOAT",
             Self::Time => "TIME",
             Self::Date => "DATE",
@@ -106,6 +109,7 @@ impl FromStr for FieldType {
         match input {
             "CHAR" => Ok(Self::Char),
             "INT" => Ok(Self::Int),
+            "LONG" => Ok(Self::Long),
             "FLOAT" => Ok(Self::Float),
             "TIME" => Ok(Self::Time),
             "DATE" => Ok(Self::Date),


### PR DESCRIPTION
Changing `RptSeq` field type from `LONG` to `INT`  in this commit [d068ae4](https://github.com/arthurlm/quickfix-rs/commit/d068ae407e194c4f9b3d0a1df2705b0d1f802cb4#diff-555b332f015f5ce11f6076ea2615122de75ba5238982244ab0f4b5431cc51063R170) causes Quickfix to send reject messages while encountering 83 field, for example:

`"8=FIXT.1.1|9=148|35=3|34=527|49=KEY|52=20240304-13:42:39.528|56=Coinbase|45=15023|58=Incorrect data format for value|371=83|372=W|373=6|10=054|"`

I have added `FieldType::Long` as i128 to aid the issue and now program is operating as normal.