### PR TITLE
💚 Fix cmake version number missmatch between quickfix-ffi and libquickfix

### DIFF
--- a/quickfix-ffi/build.rs
+++ b/quickfix-ffi/build.rs
@@ -40,6 +40,7 @@ fn main() {
 
     // Build quickfix as a static library
     let quickfix_dst = Config::new(libquickfix_build_dir)
+        .define("CMAKE_POLICY_VERSION_MINIMUM", "3.10")
         .define("HAVE_SSL", "OFF")
         .define("HAVE_MYSQL", read_cmake_opt("build-with-mysql"))
         .define("HAVE_POSTGRESQL", read_cmake_opt("build-with-postgres"))


### PR DESCRIPTION
This can be improved and should be reported upstream in QuickFix c++ library.

Associated issue: #21